### PR TITLE
Add Colab script for clinical notes to FHIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,26 @@ This project is based on Flask API and used flask-api-spec for automatically gen
 Before running FHIR Adapter ensure that BIOMED is started.
 To run FHIR Adapter for dev you need to execute `python fhirhydrant.fhir_server` with environmental variable FLASK_ENV. There are 2 values in which FLASK_ENV can be set: 'development' and 'test'.
 For now FHIR Adapter is not ready for production.
+
+## Google Colab Usage
+
+The script `scripts/clinical_notes_to_bundle.py` can be used in Google Colab to
+convert clinician notes to a FHIR bundle.
+
+Clone the repository, install the requirements and run the script:
+
+```python
+!git clone <repository-url>
+%cd text2fhir
+!pip install -r requirements.txt -r fhirhydrant/client-requirements.txt
+
+import os
+os.environ['MDL_FHIR_API_BASE'] = 'http://localhost:5000'  # update if needed
+os.environ['MDL_FHIR_TENANT_ID'] = '<your-tenant-id>'
+
+!python scripts/clinical_notes_to_bundle.py -o bundle_output.txt
+```
+
+When executed in Colab the script will prompt you to upload a `.txt` file with
+the clinician notes and will save the resulting FHIR bundle to
+`bundle_output.txt`.

--- a/scripts/clinical_notes_to_bundle.py
+++ b/scripts/clinical_notes_to_bundle.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+from pathlib import Path
+
+try:
+    from google.colab import files
+except ImportError:  # not running in Colab
+    files = None
+
+from fhirhydrant.fhir_client.utils.fhir_hydrant_client import FhirHydrantClient
+
+
+def read_text(path: Path) -> str:
+    with path.open('r', encoding='utf-8') as f:
+        return f.read()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert clinician notes to a FHIR bundle using the FHIR Hydrant API")
+    parser.add_argument('input', nargs='?', help='Path to clinician notes text file')
+    parser.add_argument('-o', '--output', default='bundle_output.txt', help='Output file for the resulting bundle')
+    args = parser.parse_args()
+
+    if args.input:
+        clinical_text = read_text(Path(args.input))
+    else:
+        if files is None:
+            parser.error('Input file is required when not running in Google Colab.')
+        uploaded = files.upload()
+        if not uploaded:
+            print('No file uploaded.')
+            return
+        name, data = next(iter(uploaded.items()))
+        clinical_text = data.decode('utf-8')
+        print(f'Read {len(clinical_text)} characters from {name}')
+
+    client = FhirHydrantClient()
+    bundle = client.post_clinical_summary(clinical_text)
+
+    output_path = Path(args.output)
+    with output_path.open('w', encoding='utf-8') as f:
+        json.dump(bundle, f, indent=2)
+    print(f'FHIR bundle written to {output_path}')
+
+    if files is not None:
+        files.download(str(output_path))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `clinical_notes_to_bundle.py` script for turning a clinician note text file into a FHIR bundle
- document how to run the new script from Google Colab

## Testing
- `pip install -r requirements.txt -r fhirhydrant/client-requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'text2phenotype')*

------
https://chatgpt.com/codex/tasks/task_b_686549921e2c8327a7bfa042c5d46c57