### PR TITLE
Add centralized settings loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+user_settings.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ This service is able to receive BIOMED clinical data and raw clinical text and t
 There are 3 preconfigured environment profiles (test, development, production):
 `FLASK_ENV=development`
 	
-Connection to Azure FHIR API is provided by getting access token from 'https://login.microsoftonline.com/' by using these parameters as environment variables:
+Connection to Azure FHIR API is provided by getting an access token from `https://login.microsoftonline.com/`.  The required values can be supplied in a single JSON file named `user_settings.json` located in the project root:
 
-`TENANT_ID=...`
+```
+{
+  "MDL_FHIR_TENANT_ID": "<tenant-id>",
+  "MDL_FHIR_CLIENT_ID": "<client-id>",
+  "MDL_FHIR_CLIENT_SECRET": "<client-secret>",
+  "MDL_FHIR_AZURE_USERNAME": "fhir_user@yoursite.onmicrosoft.com",
+  "MDL_FHIR_PASSWORD": "<password>",
+  "MDL_FHIR_API_URL": "https://text2phenotype.azurehealthcareapis.com/",
+  "MDL_FHIR_API_BASE": "http://localhost:5000"
+}
+```
 
-`CLIENT_ID=...`
-
-`CLIENT_SECRET=...`
-
-`AZURE_USERNAME=fhir_user@yoursite.onmicrosoft.com`
-
-`PASSWORD=....`
-
-`API_URL=https://text2phenotype.azurehealthcareapis.com/`
-
-These parameters are also configurable in config.json
+An example file `user_settings.example.json` is provided.  Copy it to `user_settings.json` and fill in your values.
 
 Access to FHIR resources is provided by using url: https://text2phenotype.azurehealthcareapis.com/
 
@@ -43,9 +43,9 @@ Clone the repository, install the requirements and run the script:
 %cd text2fhir
 !pip install -r requirements.txt -r fhirhydrant/client-requirements.txt
 
-import os
-os.environ['MDL_FHIR_API_BASE'] = 'http://localhost:5000'  # update if needed
-os.environ['MDL_FHIR_TENANT_ID'] = '<your-tenant-id>'
+# upload your user_settings.json if it differs from the default
+from google.colab import files
+files.upload()  # choose user_settings.json
 
 !python scripts/clinical_notes_to_bundle.py -o bundle_output.txt
 ```

--- a/fhirhydrant/fhir_server/__main__.py
+++ b/fhirhydrant/fhir_server/__main__.py
@@ -1,7 +1,10 @@
 from text2phenotype.common.log import operations_logger
 
+from settings import load_env
 from fhirhydrant.fhir_server.app.factory import create_app
 from fhirhydrant.fhir_server.fhir_server_env import FhirServerEnv
+
+load_env()
 
 
 operations_logger.info('Starting service...')

--- a/scripts/clinical_notes_to_bundle.py
+++ b/scripts/clinical_notes_to_bundle.py
@@ -2,6 +2,10 @@ import argparse
 import json
 from pathlib import Path
 
+from settings import load_env
+
+load_env()
+
 try:
     from google.colab import files
 except ImportError:  # not running in Colab

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,27 @@
+import os
+import json
+from pathlib import Path
+
+DEFAULT_SETTINGS = {
+    "MDL_FHIR_TENANT_ID": "",
+    "MDL_FHIR_CLIENT_ID": "",
+    "MDL_FHIR_CLIENT_SECRET": "",
+    "MDL_FHIR_AZURE_USERNAME": "fhir_user@yoursite.onmicrosoft.com",
+    "MDL_FHIR_PASSWORD": "",
+    "MDL_FHIR_API_URL": "https://text2phenotype.azurehealthcareapis.com/",
+    "MDL_FHIR_API_BASE": "http://localhost:5000"
+}
+
+
+def load_env(settings_path: Path = Path(__file__).with_name('user_settings.json')):
+    """Populate os.environ with values from the user settings file."""
+    data = DEFAULT_SETTINGS.copy()
+    if settings_path.exists():
+        with settings_path.open() as f:
+            try:
+                loaded = json.load(f)
+                data.update({k: v for k, v in loaded.items() if v is not None})
+            except Exception:
+                pass
+    for key, value in data.items():
+        os.environ.setdefault(key, str(value))

--- a/user_settings.example.json
+++ b/user_settings.example.json
@@ -1,0 +1,9 @@
+{
+  "MDL_FHIR_TENANT_ID": "",
+  "MDL_FHIR_CLIENT_ID": "",
+  "MDL_FHIR_CLIENT_SECRET": "",
+  "MDL_FHIR_AZURE_USERNAME": "fhir_user@yoursite.onmicrosoft.com",
+  "MDL_FHIR_PASSWORD": "",
+  "MDL_FHIR_API_URL": "https://text2phenotype.azurehealthcareapis.com/",
+  "MDL_FHIR_API_BASE": "http://localhost:5000"
+}


### PR DESCRIPTION
## Summary
- allow config via `user_settings.json`
- load settings in client script and server
- provide example settings JSON and README instructions
- ignore local settings file in git

## Testing
- `pip install -r requirements.txt -r fhirhydrant/client-requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'text2phenotype')*

------
https://chatgpt.com/codex/tasks/task_b_68654d6427b88327a5e12151ff8974ec