### PR TITLE
Fix script to load settings when run directly

### DIFF
--- a/scripts/clinical_notes_to_bundle.py
+++ b/scripts/clinical_notes_to_bundle.py
@@ -1,6 +1,11 @@
 import argparse
 import json
 from pathlib import Path
+import sys
+
+# Ensure the project root is on the module search path so that ``settings`` and
+# other local modules can be imported when the script is executed directly.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from settings import load_env
 


### PR DESCRIPTION
## Summary
- ensure main script can find the project's settings module when executed directly by adding repo root to `sys.path`

## Testing
- `pytest tests/unit/schemas/test_demographics.py::TestCase --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_b_68658e35e13483279461bc67a8e56aab